### PR TITLE
Fix typo on status named DONEWITHERROR

### DIFF
--- a/lib/Net/Hadoop/Oozie/Constants.pm
+++ b/lib/Net/Hadoop/Oozie/Constants.pm
@@ -16,7 +16,7 @@ use constant JOB_OPTIONS => qw(
 );
 
 use constant COORD_STATUS => qw(
-    DONWITHERROR
+    DONEWITHERROR
     FAILED
     KILLED
     PAUSED


### PR DESCRIPTION
This prevents filtering by `DONEWITHERROR` as it is not recognized as a valid status by the library.